### PR TITLE
Use pkg-config to get compiler and linker flags for YAZ

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,8 +1,9 @@
 require 'mkmf'
+require 'pkg-config'
 
-unless system('yaz-config')
-  $stderr.puts 'yaz does not appear to be installed'
-  exit
+unless PKGConfig.have_package('yaz')
+  $stderr.puts 'yaz development files do not appear to be installed'
+  exit(false)
 end
 
 unless have_header('yaz/zoom.h')
@@ -10,8 +11,8 @@ unless have_header('yaz/zoom.h')
   exit
 end
 
-$CFLAGS << " #{`yaz-config --cflags`} "
-$LDFLAGS << " #{`yaz-config --libs`} "
+$CFLAGS << " #{PKGConfig.cflags('yaz')} "
+$LDFLAGS << " #{PKGConfig.libs('yaz')} "
 
 create_makefile("zoom")
 


### PR DESCRIPTION
In Debian, libyaz-dev no longer ships yaz-config.
    
This patch was taken from the ruby-zoom Debian package and was originally authored by Hugh McMaster.
